### PR TITLE
fix(install): stop clearing marketplace .mcp.json to prevent MCP server loss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,13 @@ Lightweight persistent memory system for Claude Code. MCP server + hooks plugin.
 
 <claude-mem-context>
 ### Last Session
-Request: 本地还有没有没提交的代码
+Request: 提交代码发布新版本
 
 ### Key Context
-- [feature] MCP pull-based skill discovery with dispatch update (#3798)
-- [bugfix] Error: registry-retriever.mjs, dispatch.mjs, hook-update.mjs: 7a24012 fix(polis… (#3790)
-- [bugfix] Claude Code plugin .mcp.json duplicate MCP fix — move to .claude-plugin/ subdir (#3773)
-- [feature] Add 'search' action to mem_registry tool for capability discovery (#3765)
-- [bugfix] Error: toolu_019i6CyzUxCspeqseeNMrDk7.txt, install.mjs, server.mjs: 101→       … (#3763)
+- [bugfix] Error: hook.mjs: diff --git a/hook.mjs b/hook.mjs index 4cb6138..a… (#3879)
+- [bugfix] echo "HEAD: $(git rev-parse HEAD)" && echo "BASE:… → HEAD: 9fe8d03fb9a2ada59080… (#3877)
+- [bugfix] Error: dispatch-feedback.mjs: ✓ tests/dispatch-sim.test.mjs > Dispatch Simulati… (#3876)
+- [bugfix] Error: e2e.test.mjs: ✓ tests/dispatch.test.mjs > consecutive rejection… (#3875)
+- [bugfix] Error: dispatch.test.mjs: 1943|     const resource = db.prepare('SELECT wei… (#3872)
 
 </claude-mem-context>

--- a/install.mjs
+++ b/install.mjs
@@ -271,28 +271,17 @@ async function install() {
   // point to ~/.claude-mem-lite/ (latest code in dev mode via symlinks),
   // while plugin hooks use ${CLAUDE_PLUGIN_ROOT} (potentially stale marketplace copy).
   //
-  // MCP dedup: Claude Code loads .mcp.json from BOTH marketplace root (generic scan)
-  // and cache dir (plugin runtime). Keep root .mcp.json in the plugin so Claude
-  // Code can register MCP correctly, but remove stale marketplace-root copies and
-  // old global ~/.claude.json mem config to avoid duplicate registrations.
+  // MCP dedup: Claude Code copies .mcp.json from marketplace clone → plugin cache.
+  // Do NOT modify marketplace .mcp.json — it breaks the MCP server registration chain.
+  // Dedup is handled by skipping global `claude mcp add` when plugin system is active.
   const pluginDir = join(homedir(), '.claude', 'plugins', 'marketplaces', MARKETPLACE_KEY);
   const pluginHooksPath = join(pluginDir, 'hooks', 'hooks.json');
 
   if (existsSync(pluginDir)) {
-    // Clear root-level .mcp.json if it exists (stale from older git versions).
-    // Root .mcp.json is required in the installed plugin cache; only remove stale
-    // marketplace clone copies here.
-    const rootMcpPath = join(pluginDir, '.mcp.json');
-    try {
-      if (existsSync(rootMcpPath)) {
-        const pluginMcp = JSON.parse(readFileSync(rootMcpPath, 'utf8'));
-        if (pluginMcp.mcpServers?.mem) {
-          delete pluginMcp.mcpServers.mem;
-          writeFileSync(rootMcpPath, JSON.stringify(pluginMcp, null, 2) + '\n');
-          ok('Marketplace plugin: root .mcp.json cleared (source manifest now lives in claude-plugin/)');
-        }
-      }
-    } catch (e) { warn(`Marketplace MCP dedup: ${e.message}`); }
+    // NOTE: Do NOT clear marketplace .mcp.json — Claude Code copies from
+    // marketplace clone → plugin cache on updates. Clearing it causes the
+    // cache .mcp.json to lose the MCP server definition, breaking plugin MCP.
+    // Dedup is already handled by skipping global `claude mcp add` above.
 
     // Clear plugin hooks to prevent double hook execution
     try {


### PR DESCRIPTION
## Summary
- **Root cause**: `install.mjs` was deleting the MCP server definition from the marketplace clone's `.mcp.json` during dedup (lines 282-295)
- **Impact**: Claude Code copies from marketplace clone → plugin cache on updates, so the cleared `.mcp.json` propagated to cache, causing the plugin's MCP server (`plugin:*:mem`) to disappear entirely
- **Fix**: Removed the marketplace `.mcp.json` clearing code — dedup is already handled by skipping `claude mcp add` when the plugin system is active

## Test plan
- [x] All 30 test files pass (1133 tests)
- [ ] Restart Claude Code and verify `plugin:claude-mem-lite:mem` MCP server is present
- [ ] Run `node install.mjs` and confirm marketplace `.mcp.json` is not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)