### PR TITLE
feat(search+mcp): improve CJK recall and fix dev mode MCP tool loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,17 +49,16 @@ Lightweight persistent memory system for Claude Code. MCP server + hooks plugin.
 
 <claude-mem-context>
 ### Last Session
-Request: Check current project functionality and align README.md documentation; merge and clean up branches; commit and push cod…
-Completed: Updated marketplace.json version to 2.19.0; modified README.zh-CN.md, package.json, and plugin.json; updated mem servic…
-Remaining: Git branch merge/cleanup; git commit with messages and push; create GitHub release tag; verify GitHub Actions CI passes…
-Next: Execute git operations (branch cleanup, commit, push); create GitHub release via gh CLI or web UI; monitor GitHub Actio…
-Decisions: API field rename: observation_vectors → observation_files reflects data structure semantics more accurately, improving API clarity for consumers
+Completed: Reviewed 2 files: tool-schemas.mjs, server.mjs; Modified server-internals.mjs, server.mjs; Modified prompt-search-utils…
 
 ### Key Context
+- [discovery] Reviewed 2 files: tool-schemas.mjs, server.mjs (#4776)
+- [discovery] Reviewed 7 files: server.mjs, package.json, vitest.config.mjs, install.mjs +3 m… (#4749)
+- [discovery] Reviewed 9 files: server.mjs, hook-update.mjs, hook.mjs, install.mjs +5 more (#4745)
 - [bugfix] Fix PRF term extraction alignment with synonym handling (#4712) — PRF term extraction logic must match vocabulary indexing se…
 - [discovery] Reviewed 6 files: schema.mjs, server.mjs, hook-llm.mjs, tool-schemas.mjs +2 more (#4694)
-- [discovery] Reviewed 4 files: hook-llm.mjs, tool-schemas.mjs, schema.mjs, server.mjs (#4691)
-- [discovery] Reviewed 2 files: server.mjs, tfidf.mjs (#4690)
-- [discovery] Reviewed 4 files: tests, server-internals.mjs, vitest.config.mjs, server.mjs (#4673)
+
+### Working State (from /clear)
+- Working on: “以使用者的身份模拟测试一下该项目的各个功能包括用户体验,发现问题就修复问题，体验看能有效地提高claude的编程效率不。”使用loop插件循环执行三遍。ultrathink
 
 </claude-mem-context>

--- a/install.mjs
+++ b/install.mjs
@@ -353,6 +353,21 @@ async function install() {
         }
       }
     } catch (e) { warn(`Marketplace hooks dedup: ${e.message}`); }
+
+    // Sync launch.mjs to plugin cache — ensures MCP server loads dev code via symlink detection
+    try {
+      const cacheBase = join(homedir(), '.claude', 'plugins', 'cache', MARKETPLACE_KEY, 'claude-mem-lite');
+      if (existsSync(cacheBase)) {
+        const srcLaunch = join(PROJECT_DIR, 'scripts', 'launch.mjs');
+        for (const ver of readdirSync(cacheBase)) {
+          const dest = join(cacheBase, ver, 'scripts', 'launch.mjs');
+          if (existsSync(join(cacheBase, ver, 'scripts'))) {
+            copyFileSync(srcLaunch, dest);
+          }
+        }
+        ok('Plugin cache: launch.mjs synced (dev mode MCP routing)');
+      }
+    } catch (e) { warn(`Plugin cache sync: ${e.message}`); }
   }
 
   // 4. Configure hooks (merge: preserve user's existing hooks, replace ours)

--- a/nlp.mjs
+++ b/nlp.mjs
@@ -1,7 +1,7 @@
 // nlp.mjs -- FTS5 query building, synonym expansion, CJK tokenization.
 // Extracted from utils.mjs for focused module boundaries.
 
-import { BASE_STOP_WORDS } from './stop-words.mjs';
+import { BASE_STOP_WORDS, CJK_STOP_WORDS } from './stop-words.mjs';
 import { SYNONYM_MAP, CJK_COMPOUNDS } from './synonyms.mjs';
 
 // Re-export for backward compatibility (consumers import from nlp.mjs or utils.mjs)
@@ -51,7 +51,7 @@ export function cjkBigrams(text) {
   return [...new Set(tokens)].join(' ');
 }
 
-// ─── CJK Synonym Extraction ─────────────────────────────────────────────────
+// ─── CJK Keyword Extraction ─────────────────────────────────────────────────
 
 // Extract known CJK words (from SYNONYM_MAP) out of unsegmented CJK text.
 // Greedy longest-match: "数据库的全文搜索" → ["数据库", "搜索"] (skips particles/unknown).
@@ -68,6 +68,37 @@ export function extractCjkSynonymTokens(text) {
       if (text.startsWith(key, i)) {
         found.push(key);
         i += key.length;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) i++;
+  }
+  return found;
+}
+
+// Merged CJK dictionary: CJK_COMPOUNDS + CJK keys from SYNONYM_MAP — sorted longest first.
+// Gives broadest coverage: "搜索" from SYNONYM_MAP + "函数" from CJK_COMPOUNDS.
+const _cjkMergedKeys = [...new Set([...CJK_COMPOUNDS, ..._cjkSynonymKeys])]
+  .sort((a, b) => b.length - a.length);
+
+/**
+ * Extract CJK keywords using merged dictionary (CJK_COMPOUNDS + SYNONYM_MAP keys).
+ * Broader than either source alone. Filters CJK stop words.
+ * "这个函数是做什么的" → ["函数"] (not noisy bigrams)
+ * "修复数据库性能优化" → ["修复", "数据库", "性能", "优化"]
+ * "之前修复的FTS搜索排序" → ["修复", "搜索", "排序"]
+ */
+export function extractCjkKeywords(text) {
+  const found = [];
+  let i = 0;
+  while (i < text.length) {
+    if (!/[\u4e00-\u9fff\u3400-\u4dbf]/.test(text[i])) { i++; continue; }
+    let matched = false;
+    for (const word of _cjkMergedKeys) {
+      if (text.startsWith(word, i) && !CJK_STOP_WORDS.has(word)) {
+        found.push(word);
+        i += word.length;
         matched = true;
         break;
       }
@@ -124,13 +155,14 @@ export function sanitizeFtsQuery(query) {
   // Filter stop words (but keep all if filtering would empty the query)
   const filtered = tokens.filter(t => !FTS_STOP_WORDS.has(t.toLowerCase()));
   if (filtered.length > 0) tokens = filtered;
-  // Split unsegmented CJK tokens into known vocabulary words for synonym expansion.
-  // e.g. "数据库的全文搜索" → ["数据库", "搜索"] (both have EN synonyms in SYNONYM_MAP)
+  // Split unsegmented CJK tokens into known vocabulary words using CJK_COMPOUNDS dictionary.
+  // Uses broader dictionary than synonym-only extraction for better recall.
+  // e.g. "这个函数是做什么的" → ["函数"] (not noisy bigrams)
   const expandedTokens = [];
   let cjkExtracted = false;
   for (const t of tokens) {
     if (/[\u4e00-\u9fff\u3400-\u4dbf]/.test(t) && t.length > 2) {
-      const cjkWords = extractCjkSynonymTokens(t);
+      const cjkWords = extractCjkKeywords(t);
       if (cjkWords.length > 0) {
         expandedTokens.push(...cjkWords);
         cjkExtracted = true;
@@ -146,7 +178,7 @@ export function sanitizeFtsQuery(query) {
   // Skip bigrams when CJK synonym extraction already produced meaningful tokens —
   // bigrams joined with AND would make the query too restrictive.
   const bigrams = cjkExtracted ? null : cjkBigrams(cleaned);
-  const bigramSet = new Set(bigrams ? bigrams.split(' ').filter(Boolean) : []);
+  const bigramSet = new Set(bigrams ? bigrams.split(' ').filter(b => b && !CJK_STOP_WORDS.has(b)) : []);
   const hasBigrams = bigramSet.size > 0;
   const finalTokens = [];
   const seen = new Set();

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -2,9 +2,10 @@
 // launch.mjs — Auto-installs dependencies then starts MCP server
 // Uses only Node built-ins so it works before npm install
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, lstatSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { homedir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = process.env.CLAUDE_PLUGIN_ROOT || join(__dirname, '..');
@@ -19,4 +20,15 @@ if (!existsSync(join(ROOT, 'node_modules', 'better-sqlite3'))) {
   process.stderr.write('[claude-mem-lite] Dependencies installed\n');
 }
 
-await import(new URL('../server.mjs', import.meta.url).href);
+// Dev mode: prefer ~/.claude-mem-lite/server.mjs (symlinked to source) over
+// CLAUDE_PLUGIN_ROOT (potentially stale plugin cache). This ensures the MCP
+// server always runs the latest code when installed with `install --dev`.
+const devServer = join(homedir(), '.claude-mem-lite', 'server.mjs');
+let useDevServer = false;
+try { useDevServer = existsSync(devServer) && lstatSync(devServer).isSymbolicLink(); } catch {}
+
+if (useDevServer) {
+  await import(pathToFileURL(devServer).href);
+} else {
+  await import(new URL('../server.mjs', import.meta.url).href);
+}

--- a/scripts/prompt-search-utils.mjs
+++ b/scripts/prompt-search-utils.mjs
@@ -10,7 +10,11 @@ const SLASH_CMD_RE = /^\//;
 const PURE_OP_RE = /^(git\s+(commit|push|merge)|npm\s+(publish|deploy))\b/i;
 
 export function shouldSkip(text) {
-  if (!text || text.length < 8) return true;
+  if (!text) return true;
+  // CJK characters carry ~3x semantic weight per char vs Latin
+  const cjkCount = (text.match(/[\u4e00-\u9fff\u3400-\u4dbf]/g) || []).length;
+  const effectiveLen = (text.length - cjkCount) + cjkCount * 3;
+  if (effectiveLen < 8) return true;
   const trimmed = text.trim();
   if (CONFIRM_RE.test(trimmed)) return true;
   if (SLASH_CMD_RE.test(trimmed)) return true;

--- a/server-internals.mjs
+++ b/server-internals.mjs
@@ -74,7 +74,7 @@ export function reRankWithContext(db, results, project) {
  * Mutates result objects in-place by adding superseded=true flag.
  * @param {object[]} results Array of search result objects with source, files_modified, date, importance
  */
-export function markSuperseded(db, results) {
+export function markSuperseded(results) {
   if (!results || results.length === 0) return;
   // Build map: file → [result objects], only for obs with files
   const fileMap = new Map();

--- a/server.mjs
+++ b/server.mjs
@@ -569,7 +569,7 @@ server.registerTool(
     if (ftsQuery && results.some(r => r.source === 'obs')) {
       const obsResults = results.filter(r => r.source === 'obs');
       reRankWithContext(db, obsResults, currentProject);
-      markSuperseded(db, obsResults);
+      markSuperseded(obsResults);
       results.sort((a, b) => (a.score ?? 0) - (b.score ?? 0));
     }
 

--- a/stop-words.mjs
+++ b/stop-words.mjs
@@ -14,3 +14,22 @@ export const BASE_STOP_WORDS = new Set([
   'all', 'each', 'every', 'both', 'few', 'more', 'most', 'other', 'some',
   'such', 'than', 'too', 'very', 'just', 'also', 'then', 'so', 'if',
 ]);
+
+/** CJK stop words — particles, function words, and fillers that add noise to FTS queries. */
+export const CJK_STOP_WORDS = new Set([
+  // Particles & structural
+  '的', '了', '是', '在', '有', '和', '与', '被', '把', '给',
+  '个', '这', '那', '也', '就', '都', '而', '及', '或', '但',
+  '还', '到', '让', '很', '得', '着', '过', '会', '要',
+  '能', '不', '没',
+  // Question words (intent detection handles these separately)
+  '什么', '怎么', '如何', '为何', '哪个',
+  // Quantifiers & demonstratives
+  '一下', '一些', '一个', '一种',
+  // Directional/auxiliary
+  '来', '去', '做', '从', '向', '比', '对',
+  // Sentence-final particles
+  '吗', '吧', '呢', '呀', '啊', '嗯', '哦',
+  // Common filler phrases
+  '看看', '帮我', '没有', '可以', '怎么样',
+]);

--- a/synonyms.mjs
+++ b/synonyms.mjs
@@ -120,11 +120,26 @@ export const SYNONYM_PAIRS = [
   ['打包', 'bundle'], ['类型', 'type'], ['类型', 'typescript'],
   // Errors
   ['错误', 'error'], ['异常', 'exception'],
+  ['报错', 'error'], ['崩溃', 'crash'],
   // Infrastructure
   ['容器', 'container'], ['容器', 'docker'],
   ['集群', 'cluster'], ['集群', 'kubernetes'],
   ['网关', 'gateway'], ['负载', 'load balancing'],
   ['队列', 'queue'], ['序列化', 'serialize'],
+  // Code structure (missing from earlier CJK pairs)
+  ['函数', 'function'], ['变量', 'variable'],
+  ['模块', 'module'], ['框架', 'framework'],
+  ['编译', 'compile'], ['服务器', 'server'],
+  ['前端', 'frontend'], ['后端', 'backend'],
+  ['优化', 'optimize'], ['优化', 'optimization'],
+  ['架构', 'architecture'], ['设计', 'design'],
+  ['文档', 'documentation'], ['文档', 'docs'],
+  ['版本', 'version'], ['分支', 'branch'],
+  ['提交', 'commit'], ['推送', 'push'],
+  ['合并', 'merge'], ['升级', 'upgrade'],
+  ['安装', 'install'], ['导入', 'import'],
+  ['导出', 'export'], ['状态', 'state'],
+  ['系统', 'system'], ['算法', 'algorithm'],
 ];
 
 // ─── Bidirectional SYNONYM_MAP (case-insensitive) ──────────────────────────────
@@ -160,7 +175,7 @@ export const CJK_COMPOUNDS = new Set([
   '报错', '崩溃', '泄露', '溢出', '死锁', '超时', '中断', '异常', '故障',
   // architecture
   '架构', '设计', '方案', '规划', '文档', '注释', '版本', '分支', '依赖',
-  '性能', '安全', '漏洞', '补丁',
+  '性能', '安全', '漏洞', '补丁', '系统', '算法',
 ]);
 
 // ─── Dispatch Synonyms (unidirectional, broader groupings) ──────────────────

--- a/tests/integration.test.mjs
+++ b/tests/integration.test.mjs
@@ -50,7 +50,7 @@ describe('search pipeline integration', () => {
     reRankWithContext(db, results, 'test');
 
     // Step 3: markSuperseded
-    markSuperseded(db, results);
+    markSuperseded(results);
 
     // The older lower-importance auth.js obs should be superseded
     const oldAuth = results.find(r => r.title.includes('token refresh'));

--- a/tests/phase1-temporal.test.mjs
+++ b/tests/phase1-temporal.test.mjs
@@ -154,7 +154,7 @@ describe('supersession persistence', () => {
     const results = db.prepare('SELECT id, type, title, created_at as date, files_modified, importance FROM observations ORDER BY created_at_epoch ASC').all();
     const searchResults = results.map(r => ({ source: 'obs', ...r }));
 
-    markSuperseded(db, searchResults);
+    markSuperseded(searchResults);
 
     // In-memory flag should be set
     expect(searchResults[0].superseded).toBe(true);

--- a/tests/server-internals.test.mjs
+++ b/tests/server-internals.test.mjs
@@ -92,7 +92,7 @@ describe('markSuperseded', () => {
       { source: 'obs', id: 1, date: '2026-01-01', files_modified: '["auth.js"]', importance: 1 },
       { source: 'obs', id: 2, date: '2026-02-01', files_modified: '["auth.js"]', importance: 2 },
     ];
-    markSuperseded(null, results);
+    markSuperseded(results);
     expect(results[0].superseded).toBe(true);
     expect(results[1].superseded).toBeUndefined();
   });
@@ -102,7 +102,7 @@ describe('markSuperseded', () => {
       { source: 'obs', id: 1, date: '2026-01-01', files_modified: '["auth.js"]', importance: 3 },
       { source: 'obs', id: 2, date: '2026-02-01', files_modified: '["auth.js"]', importance: 1 },
     ];
-    markSuperseded(null, results);
+    markSuperseded(results);
     expect(results[0].superseded).toBeUndefined(); // imp 3 > newest imp 1
     expect(results[1].superseded).toBeUndefined(); // newest
   });
@@ -111,7 +111,7 @@ describe('markSuperseded', () => {
     const results = [
       { source: 'obs', id: 1, date: '2026-01-01', files_modified: '["only.js"]', importance: 1 },
     ];
-    markSuperseded(null, results);
+    markSuperseded(results);
     expect(results[0].superseded).toBeUndefined();
   });
 
@@ -121,7 +121,7 @@ describe('markSuperseded', () => {
       { source: 'obs', id: 2, date: '2026-02-01', files_modified: '["b.js","c.js"]', importance: 1 },
       { source: 'obs', id: 3, date: '2026-03-01', files_modified: '["c.js","d.js"]', importance: 1 },
     ];
-    markSuperseded(null, results);
+    markSuperseded(results);
     // For b.js: #1 (oldest) superseded by #2 (newest for b.js)
     expect(results[0].superseded).toBe(true);
     // For c.js: #2 superseded by #3 (newest for c.js)
@@ -130,9 +130,9 @@ describe('markSuperseded', () => {
   });
 
   it('handles empty results', () => {
-    expect(() => markSuperseded(null, [])).not.toThrow();
-    expect(() => markSuperseded(null, null)).not.toThrow();
-    expect(() => markSuperseded(null, undefined)).not.toThrow();
+    expect(() => markSuperseded([])).not.toThrow();
+    expect(() => markSuperseded(null)).not.toThrow();
+    expect(() => markSuperseded(undefined)).not.toThrow();
   });
 });
 

--- a/tests/server.test.mjs
+++ b/tests/server.test.mjs
@@ -473,7 +473,7 @@ describe('markSuperseded', () => {
       { source: 'obs', id: 1, date: '2026-01-01', files_modified: '["auth.js"]', importance: 1 },
       { source: 'obs', id: 2, date: '2026-02-01', files_modified: '["auth.js"]', importance: 2 },
     ];
-    markSuperseded(null, results);
+    markSuperseded(results);
     expect(results[0].superseded).toBe(true);  // old, imp=1 <= newest imp=2
     expect(results[1].superseded).toBeUndefined();  // newest
   });
@@ -483,7 +483,7 @@ describe('markSuperseded', () => {
       { source: 'obs', id: 1, date: '2026-01-01', files_modified: '["auth.js"]', importance: 3 },
       { source: 'obs', id: 2, date: '2026-02-01', files_modified: '["auth.js"]', importance: 1 },
     ];
-    markSuperseded(null, results);
+    markSuperseded(results);
     expect(results[0].superseded).toBeUndefined();  // imp=3 > newest imp=1
     expect(results[1].superseded).toBeUndefined();  // newest
   });
@@ -493,7 +493,7 @@ describe('markSuperseded', () => {
       { source: 'obs', id: 1, date: '2026-01-01', importance: 1 },
       { source: 'session', id: 2, date: '2026-02-01' },
     ];
-    expect(() => markSuperseded(null, results)).not.toThrow();
+    expect(() => markSuperseded(results)).not.toThrow();
   });
 });
 

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -171,8 +171,8 @@ describe('sanitizeFtsQuery', () => {
   it('handles mixed hyphens and operators', () => {
     // "next-auth" stays quoted (has hyphen), "error" expands via synonym map
     // Uses AND joiner because of parenthesized group
-    // "error" has abbreviation "err", semantic synonyms "bug", "failure", and CJK "错误"
-    expect(sanitizeFtsQuery('-next-auth error')).toBe('"next-auth" AND (error OR err OR bug OR failure OR 错误)');
+    // "error" has abbreviation "err", semantic synonyms "bug", "failure", CJK "错误", "报错"
+    expect(sanitizeFtsQuery('-next-auth error')).toBe('"next-auth" AND (error OR err OR bug OR failure OR 错误 OR 报错)');
   });
 
   it('expands abbreviation synonyms', () => {
@@ -199,10 +199,12 @@ describe('sanitizeFtsQuery', () => {
   });
 
   it('appends CJK bigrams for Chinese phrase matching', () => {
-    // "系统崩溃" → individual chars skipped, bigrams "系统 统崩 崩溃" used
+    // "系统崩溃" → extracted via merged CJK dictionary as compound words with synonyms
     const result = sanitizeFtsQuery('系统崩溃');
-    expect(result).toContain('系统');
-    expect(result).toContain('崩溃');
+    expect(result).toContain('系统');  // from CJK_COMPOUNDS
+    expect(result).toContain('崩溃');  // from CJK_COMPOUNDS + SYNONYM_MAP → (崩溃 OR crash)
+    expect(result).toContain('system'); // synonym for 系统
+    expect(result).toContain('crash');  // synonym for 崩溃
   });
 
   it('handles mixed CJK and Latin tokens with bigrams', () => {
@@ -214,8 +216,8 @@ describe('sanitizeFtsQuery', () => {
 
   it('skips single CJK chars when bigrams available', () => {
     const result = sanitizeFtsQuery('系统');
-    // Should use bigram "系统" not individual chars "系" and "统"
-    expect(result).toBe('系统');
+    // "系统" is now in CJK_COMPOUNDS + SYNONYM_MAP → expanded with synonym
+    expect(result).toBe('(系统 OR system)');
   });
 
   it('preserves single CJK chars when no bigrams possible', () => {
@@ -291,14 +293,14 @@ describe('cjkBigrams', () => {
   });
 
   it('generates bigrams from CJK runs', () => {
-    // Dictionary-based: "系统" and "崩溃" are compounds, "统崩" is bigram fallback
-    expect(cjkBigrams('系统崩溃')).toBe('系统 统崩 崩溃');
+    // Dictionary-based: "系统" and "崩溃" are both in CJK_COMPOUNDS → clean tokens
+    expect(cjkBigrams('系统崩溃')).toBe('系统 崩溃');
     expect(cjkBigrams('修复')).toBe('修复');
   });
 
   it('handles multiple CJK runs separated by non-CJK', () => {
-    // Dictionary: "系统","修复","服务器","崩溃" are compounds; "统修" is bigram fallback
-    expect(cjkBigrams('系统修复 服务器崩溃')).toBe('系统 统修 修复 服务器 崩溃');
+    // Dictionary: "系统","修复","服务器","崩溃" are all compounds → clean tokens
+    expect(cjkBigrams('系统修复 服务器崩溃')).toBe('系统 修复 服务器 崩溃');
   });
 
   it('skips single CJK characters (no bigram from length 1)', () => {

--- a/utils.mjs
+++ b/utils.mjs
@@ -9,7 +9,7 @@ import { execSync } from 'child_process';
 // Backward compatibility: all consumers import from utils.mjs
 
 export { DECAY_HALF_LIFE_BY_TYPE, DEFAULT_DECAY_HALF_LIFE_MS, OBS_BM25, SESS_BM25, TYPE_DECAY_CASE, OBS_FTS_COLUMNS } from './scoring-sql.mjs';
-export { cjkBigrams, extractCjkSynonymTokens, SYNONYM_MAP, expandToken, sanitizeFtsQuery, relaxFtsQueryToOr, FTS_STOP_WORDS, CJK_COMPOUNDS } from './nlp.mjs';
+export { cjkBigrams, extractCjkSynonymTokens, extractCjkKeywords, SYNONYM_MAP, expandToken, sanitizeFtsQuery, relaxFtsQueryToOr, FTS_STOP_WORDS, CJK_COMPOUNDS } from './nlp.mjs';
 export { resolveProject, _resetProjectCache } from './project-utils.mjs';
 export { scrubSecrets, SECRET_PATTERNS } from './secret-scrub.mjs';
 export { truncate, typeIcon, fmtDate, fmtTime, isoWeekKey } from './format-utils.mjs';


### PR DESCRIPTION
## Summary
- **CJK search recall improvement**: Add `extractCjkKeywords()` using merged CJK_COMPOUNDS + SYNONYM_MAP dictionary, CJK stop words filtering, 24 new CJK↔EN synonym pairs, and CJK-aware effective length calculation in `shouldSkip()`
- **Dev mode MCP fix**: `launch.mjs` detects dev symlink and loads dev server instead of stale plugin cache; `install.mjs --dev` auto-syncs launch.mjs to cache
- **Code cleanup**: Remove unused `db` parameter from `markSuperseded()` across 5 files

## Test plan
- [x] 999 tests pass (0 failures)
- [x] Benchmark unchanged: P95=0.17ms, Precision=98.3%, Recall=88.5%
- [x] CJK queries verified: "这个函数是做什么的" → `(函数 OR function)` instead of 7 noisy bigrams
- [x] CJK prompt search: "数据库搜索优化" returns results (was empty before)
- [x] Dev mode symlink detection works in launch.mjs
- [x] Lint passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search support for Chinese/Japanese (CJK) languages with improved keyword extraction and stop-word filtering.
  * Added automatic synchronization of plugin cache files during installation for developer environments.
  * Expanded synonym mappings to cover additional technical and domain-specific terms across multiple languages.

* **Refactor**
  * Improved search query processing and in-memory result ranking.
  * Added developer symlink support for local server environments.

* **Tests**
  * Updated test cases to reflect improved CJK tokenization and synonym expansion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->