### PR TITLE
fix(integration): improve error detection and tool description discoverability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,23 +49,20 @@ Lightweight persistent memory system for Claude Code. MCP server + hooks plugin.
 
 <claude-mem-context>
 ### Last Session
-Request: 好
-Completed: Modified hook.mjs, mem-cli.mjs
-Remaining: hook.mjs: "// Auto-purge: delete stale observation…" → "// Auto-maintain: cleanup + decay + boo…"
+Request: 检查下我们插件上下文token占用情况
 
 ### File Lessons
-- mem-cli.mjs: CLI tools must validate arguments explicitly and fail fast with clear error messages rather than si… (#5243)
+- utils.mjs: Weak regex in command/function name parsers silently skip edge cases — catch with typed test fixtur… (#5588)
+- hook-llm.mjs: FTS5 column name mismatches silently trigger degraded mode without explicit error — need defensive … (#5571)
 
 ### Key Context
-- [discovery] Reviewed 5 files: mem, hook.mjs, hook-episode.mjs, hook-llm.mjs +1 more (#5323)
-- [bugfix] Error: mem-cli.mjs: mem Timeline (most recent 11): # 5304 📝 5m ago  … (#5320)
-- [bugfix] # Test compress preview node cli.mjs compress --a… → [mem] No candidates for co… (#5315)
-- [change] Modified cli.mjs (#5272)
-- [bugfix] Error: mem-cli.mjs: mem 5 results for error debugging fix performance… (#5245)
+- [bugfix] Error: schema.mjs: --- False positive test --- Old regex match: true… (#5624)
+- [bugfix] # Scenario 1: 模拟 session-start — 新描述会在 MCP instru… → === Scenario 1: Session St… (#5621)
+- [bugfix] Fix makeEntryDesc false-positive ERROR labeling + register missing PreToolUse h… (#5597)
+- [bugfix] Error: test.mjs: Error: Cannot find module better-sqlite3 at requi… (#5581)
+- [bugfix] Error: schema.mjs: mem Timeline (most recent 11): # 5547 🔴 24m ago … (#5563)
 
 ### Working State (from /clear)
-- Working on: 好
-- Unfinished: hook.mjs: "// Auto-purge: delete stale observation…" → "// Auto-maintain: cleanup + decay + boo…"
-- Key files: hook.mjs, mem-cli.mjs
+- Working on: 检查下我们插件上下文token占用情况
 
 </claude-mem-context>

--- a/commands/mem.md
+++ b/commands/mem.md
@@ -1,5 +1,5 @@
 ---
-description: Search and manage project memory (observations, sessions, prompts)
+description: "Search and manage project memory (observations, sessions, prompts). Use when: user asks about past work, wants to find a previous bugfix, check project history, save a decision, or manage stored memories"
 ---
 
 # Memory

--- a/commands/recent.md
+++ b/commands/recent.md
@@ -1,5 +1,5 @@
 ---
-description: Show recent memory observations
+description: "Show recent memory observations. Use when: checking what happened recently, reviewing session progress, or verifying recent changes were captured"
 argument-hint: [count]
 ---
 

--- a/commands/search.md
+++ b/commands/search.md
@@ -1,5 +1,5 @@
 ---
-description: Search memory for past bugfixes, decisions, discoveries
+description: "Search memory for past bugfixes, decisions, discoveries. Use when: encountering a familiar error, investigating a module before changes, or looking for prior solutions to a similar problem"
 argument-hint: <query>
 ---
 

--- a/commands/timeline.md
+++ b/commands/timeline.md
@@ -1,5 +1,5 @@
 ---
-description: Browse memory timeline around an observation
+description: "Browse memory timeline around an observation. Use when: exploring what happened before/after a specific event, understanding the sequence of changes that led to a bug, or reviewing chronological context"
 argument-hint: <observation_id>
 ---
 

--- a/hook-llm.mjs
+++ b/hook-llm.mjs
@@ -24,7 +24,25 @@ function buildFtsTextField(obs) {
   const factsText = Array.isArray(obs.facts) ? obs.facts.join(' ') : '';
   const aliasesText = obs.searchAliases || '';
   const bigramText = cjkBigrams((obs.title || '') + ' ' + (obs.narrative || ''));
-  return { conceptsText, factsText, textField: [conceptsText, factsText, aliasesText, bigramText].filter(Boolean).join(' ') };
+
+  // Degraded fallback: when LLM enrichment is missing, extract lightweight keywords
+  // from title + narrative so degraded observations remain FTS-searchable
+  let fallbackText = '';
+  if (!conceptsText && !factsText && !aliasesText) {
+    const raw = (obs.title || '') + ' ' + (obs.narrative || '');
+    // Extract file basenames (without extension) as searchable terms
+    const fileNames = [...new Set(
+      [...raw.matchAll(/\b([\w.-]+\.(?:mjs|js|ts|tsx|jsx|py|rs|go|vue|css|html|json|yaml|yml|md|sh|sql|toml|cfg))\b/g)]
+        .map(m => m[1].replace(/\.[^.]+$/, ''))
+    )];
+    // Extract error keywords from "→ ERROR: ..." patterns
+    const errorTerms = raw.split(/→ ERROR[: ]+/).slice(1)
+      .map(s => s.split(/[;{[\]"\\|→\n]/)[0].trim())
+      .filter(t => t.length >= 4 && t.length <= 50);
+    fallbackText = [...fileNames, ...errorTerms].join(' ');
+  }
+
+  return { conceptsText, factsText, textField: [conceptsText, factsText, aliasesText, bigramText, fallbackText].filter(Boolean).join(' ') };
 }
 
 /**
@@ -244,8 +262,14 @@ export function buildDegradedTitle(episode) {
       // Extract meaningful error text from "cmd → ERROR: ..." format
       const errMatch = errEntry.desc.match(/→ ERROR: (.{3,80})/);
       if (errMatch) {
-        // Clean JSON/noise from the error snippet
-        const cleaned = errMatch[1].replace(/[{"[\]]/g, '').replace(/\\n/g, ' ').trim();
+        // Clean JSON/noise/tabs/CI-status from the error snippet
+        const cleaned = errMatch[1]
+          .replace(/\t/g, ' ')
+          .replace(/[{"[\]]/g, '')
+          .replace(/\\n/g, ' ')
+          .replace(/\b(?:in_progress|completed|queued|failure|success|waiting)\b/gi, '')
+          .replace(/\s{2,}/g, ' ')
+          .trim();
         if (cleaned.length >= 4) errorHint = `: ${truncate(cleaned, 50)}`;
       }
     }
@@ -267,7 +291,10 @@ export function buildDegradedTitle(episode) {
   // No files: strip raw output (JSON, arrays, long tails) from Bash descriptions
   const desc = episode.entries[0]?.desc || '(no description)';
   return desc.replace(/ → (?:ERROR: )?[[{].*$/, hasError ? ' (error)' : '')
-    .replace(/ → .*---EXIT:\d+$/, hasError ? ' (error)' : '');
+    .replace(/ → .*---EXIT:\d+$/, hasError ? ' (error)' : '')
+    .replace(/\t/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
 }
 
 /**

--- a/hook.mjs
+++ b/hook.mjs
@@ -169,7 +169,7 @@ async function handlePostToolUse() {
   // Build episode entry
   const entry = {
     tool: tool_name,
-    desc: scrubSecrets(makeEntryDesc(tool_name, toolInput, resp)),
+    desc: scrubSecrets(makeEntryDesc(tool_name, toolInput, resp, bashSig)),
     files,
     ts: Date.now(),
     isError: bashSig?.isError || false,
@@ -516,6 +516,24 @@ async function handleSessionStart() {
           )
         `).run();
         if (boosted.changes > 0) debugLog('DEBUG', 'auto-maintain', `boosted ${boosted.changes} frequently-accessed observations`);
+
+        // Auto-dedup: merge near-identical observations (same title, same project, within 1h)
+        const dupPairs = db.prepare(`
+          SELECT a.id as keep_id, b.id as remove_id
+          FROM observations a
+          JOIN observations b ON a.title = b.title AND a.project = b.project
+            AND a.id < b.id
+            AND ABS(a.created_at_epoch - b.created_at_epoch) < 3600000
+            AND COALESCE(a.compressed_into, 0) = 0
+            AND COALESCE(b.compressed_into, 0) = 0
+          LIMIT 20
+        `).all();
+        if (dupPairs.length > 0) {
+          const removeIds = dupPairs.map(p => p.remove_id);
+          const ph = removeIds.map(() => '?').join(',');
+          db.prepare(`UPDATE observations SET superseded_at = ?, superseded_by = 'auto-dedup' WHERE id IN (${ph})`).run(Date.now(), ...removeIds);
+          debugLog('DEBUG', 'auto-maintain', `auto-deduped ${dupPairs.length} near-identical observations`);
+        }
 
         // Mark maintenance as done (24h gate) — even though compression runs in background
         writeFileSync(maintainFile, JSON.stringify({ epoch: Date.now() }));

--- a/mem-cli.mjs
+++ b/mem-cli.mjs
@@ -164,20 +164,6 @@ function cmdSearch(db, args) {
         LIMIT ?
       `).all(...typeParams);
     }
-    // Tier post-filter
-    if (tier && obsRows.length > 0) {
-      const rowIds = obsRows.map(r => r.id);
-      const ph = rowIds.map(() => '?').join(',');
-      const fullRows = db.prepare(
-        `SELECT id, compressed_into, superseded_at, memory_session_id, project, importance, last_accessed_at, created_at_epoch, type FROM observations WHERE id IN (${ph})`
-      ).all(...rowIds);
-      const rowMap = new Map(fullRows.map(r => [r.id, r]));
-      const tierCtx = { now: Date.now(), currentProject: project || inferProject(), currentSessionId: '' };
-      obsRows = obsRows.filter(r => {
-        const full = rowMap.get(r.id);
-        return full && computeTier(full, tierCtx) === tier;
-      });
-    }
     for (const r of obsRows) results.push({ ...r, _source: 'obs', score: r.score ?? 0 });
 
     // Concept co-occurrence + PRF expansion (aligned with MCP searchObservations)
@@ -219,6 +205,27 @@ function cmdSearch(db, args) {
               }
             }
           } catch { /* PRF is best-effort */ }
+        }
+      }
+    }
+
+    // Tier post-filter — applied to ALL obs results (initial + expansion + PRF)
+    if (tier) {
+      const obsInResults = results.filter(r => r._source === 'obs');
+      if (obsInResults.length > 0) {
+        const obsIds = obsInResults.map(r => r.id);
+        const ph = obsIds.map(() => '?').join(',');
+        const fullRows = db.prepare(
+          `SELECT id, compressed_into, superseded_at, memory_session_id, project, importance, last_accessed_at, created_at_epoch, type FROM observations WHERE id IN (${ph})`
+        ).all(...obsIds);
+        const rowMap = new Map(fullRows.map(r => [r.id, r]));
+        const tierCtx = { now: Date.now(), currentProject: project || inferProject(), currentSessionId: '' };
+        const allowedIds = new Set();
+        for (const [id, full] of rowMap) {
+          if (computeTier(full, tierCtx) === tier) allowedIds.add(id);
+        }
+        for (let i = results.length - 1; i >= 0; i--) {
+          if (results[i]._source === 'obs' && !allowedIds.has(results[i].id)) results.splice(i, 1);
         }
       }
     }
@@ -1663,16 +1670,22 @@ function cmdRegistry(_memDb, args) {
 
     if (action === 'list') {
       const typeFilter = flags.type;
+      const rawLimit = parseInt(flags.limit, 10);
+      const listLimit = Number.isInteger(rawLimit) && rawLimit > 0 ? rawLimit : 20;
       const where = typeFilter ? 'WHERE type = ? AND status = ?' : 'WHERE status = ?';
       const params = typeFilter ? [typeFilter, 'active'] : ['active'];
-      const resources = rdb.prepare(`
+      const allResources = rdb.prepare(`
         SELECT name, type, invocation_name, recommend_count, adopt_count, capability_summary
-        FROM resources ${where} ORDER BY type, name
+        FROM resources ${where} ORDER BY adopt_count DESC, recommend_count DESC, type, name
       `).all(...params);
-      if (resources.length === 0) { out('[mem] No resources found.'); return; }
-      out(`[mem] Resources (${resources.length}):`);
+      if (allResources.length === 0) { out('[mem] No resources found.'); return; }
+      const resources = allResources.slice(0, listLimit);
+      out(`[mem] Resources (showing ${resources.length} of ${allResources.length}):`);
       for (const r of resources) {
         out(`  ${r.type === 'skill' ? 'S' : 'A'} ${r.name}${r.invocation_name ? ` (${r.invocation_name})` : ''} — rec:${r.recommend_count} adopt:${r.adopt_count} — ${truncate(r.capability_summary || '', 50)}`);
+      }
+      if (allResources.length > listLimit) {
+        out(`[mem] Use --limit N to see more, or "registry search <query>" to find specific resources.`);
       }
       return;
     }
@@ -1831,7 +1844,7 @@ Commands:
     --limit N           Max entries per tier (default 5)
 
   registry <action>     Manage tool resource registry
-    list                List all resources [--type skill|agent]
+    list                List resources [--type skill|agent] [--limit N] (default 20)
     stats               Registry statistics
     search <query>      Search resources [--type skill|agent] [--category C] [--quality Q]
     import              Import resource --name N --resource-type T [--repo-url U] [--local-path P] [--use-cases U]

--- a/server.mjs
+++ b/server.mjs
@@ -514,7 +514,7 @@ function formatSearchOutput(paginatedResults, args, ftsQuery, totalCount, isCros
 server.registerTool(
   'mem_search',
   {
-    description: 'FTS5 full-text search across observations, sessions, and prompts with BM25 ranking. Returns compact index (use mem_get for details).',
+    description: 'Search project memory for past bugfixes, decisions, and discoveries. Use when: encountering a familiar error, investigating a module before changes, or looking for prior art on a problem. Returns compact index (use mem_get for full details).',
     inputSchema: memSearchSchema,
   },
   safeHandler(async (args) => {
@@ -650,7 +650,7 @@ server.registerTool(
 server.registerTool(
   'mem_recent',
   {
-    description: 'Show most recent observations, ordered by time. Quick way to see latest activity without a search query.',
+    description: 'Show most recent observations. Use when: checking what happened recently in the project, reviewing progress after being away, or verifying that a recent change was captured.',
     inputSchema: memRecentSchema,
   },
   safeHandler(async (args) => {
@@ -689,7 +689,7 @@ server.registerTool(
 server.registerTool(
   'mem_timeline',
   {
-    description: 'Browse observations as a timeline around an anchor point. Use query to auto-find anchor, or specify anchor ID directly.',
+    description: 'Browse observations as a timeline around an anchor point. Use when: exploring what happened before/after a specific observation, understanding the sequence of changes that led to a bug, or reviewing a session chronologically.',
     inputSchema: memTimelineSchema,
   },
   safeHandler(async (args) => {
@@ -790,7 +790,7 @@ server.registerTool(
 server.registerTool(
   'mem_get',
   {
-    description: 'Get full details for one or more records by ID. Use after mem_search to drill into specific records.',
+    description: 'Get full details for one or more records by ID. Use when: hook-injected context mentions a relevant observation ID, or after mem_search to drill into specific results for narrative, lesson_learned, and file details.',
     inputSchema: memGetSchema,
   },
   safeHandler(async (args) => {
@@ -912,7 +912,7 @@ server.registerTool(
 server.registerTool(
   'mem_save',
   {
-    description: 'Manually save a memory/observation. Use for important findings, decisions, or notes worth preserving.',
+    description: 'Save a memory/observation. Use when: solving a non-obvious bug (save the lesson), making an architecture decision, discovering something not obvious from code alone, or when the user asks to remember something.',
     inputSchema: memSaveSchema,
   },
   safeHandler(async (args) => {
@@ -994,7 +994,7 @@ server.registerTool(
 server.registerTool(
   'mem_stats',
   {
-    description: 'Get statistics about stored memories: counts, types, projects, recent activity.',
+    description: 'Get memory statistics: counts, types, projects, daily activity, data health. Use when: assessing memory system health, checking how much project history exists, or diagnosing search quality issues.',
     inputSchema: memStatsSchema,
   },
   safeHandler(async (args) => {

--- a/tests/hook-llm.test.mjs
+++ b/tests/hook-llm.test.mjs
@@ -23,7 +23,7 @@ vi.mock('../hook-shared.mjs', async () => {
   };
 });
 
-import { saveObservation, handleLLMEpisode, handleLLMSummary } from '../hook-llm.mjs';
+import { saveObservation, handleLLMEpisode, handleLLMSummary, buildDegradedTitle } from '../hook-llm.mjs';
 import { openDb, callLLM } from '../hook-shared.mjs';
 import { acquireLLMSlot } from '../hook-semaphore.mjs';
 
@@ -842,5 +842,38 @@ describe('lesson_learned and search_aliases extraction', () => {
 
     process.argv[3] = origArgv3;
     db._realClose();
+  });
+});
+
+// ─── buildDegradedTitle ─────────────────────────────────────────────────────
+
+describe('buildDegradedTitle', () => {
+  it('strips tab characters and CI status from error hints', () => {
+    const episode = {
+      files: ['plugin.json'],
+      entries: [{
+        tool: 'Bash',
+        desc: 'gh run list → ERROR: in_progress\t\tchore(release): bump version',
+        isError: true,
+      }],
+    };
+    const title = buildDegradedTitle(episode);
+    expect(title).not.toMatch(/\t/);
+    expect(title).not.toMatch(/in_progress/);
+    expect(title).toMatch(/^Error: plugin\.json/);
+  });
+
+  it('strips tabs from no-file fallback desc', () => {
+    const episode = {
+      files: [],
+      entries: [{
+        tool: 'Bash',
+        desc: 'check\tstatus\there',
+        isError: false,
+      }],
+    };
+    const title = buildDegradedTitle(episode);
+    expect(title).not.toMatch(/\t/);
+    expect(title).toBe('check status here');
   });
 });

--- a/tests/user-prompt-search.test.mjs
+++ b/tests/user-prompt-search.test.mjs
@@ -288,9 +288,10 @@ describe('user-prompt-search subprocess integration', () => {
     cleanupTestFiles();
     // Remove cooldown file before each test
     try { if (existsSync(COOLDOWN_FILE)) unlinkSync(COOLDOWN_FILE); } catch {}
-    // Create a test directory with a DB
+    // Create a test directory with a DB (clean slate — rmSync first to prevent stale WAL data)
     testDir = resolve(import.meta.dirname, '.tmp-prompt-search-dir');
-    try { mkdirSync(testDir, { recursive: true }); } catch {}
+    try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+    mkdirSync(testDir, { recursive: true });
     const dbPath = join(testDir, 'claude-mem-lite.db');
     db = createFileDb(dbPath);
     insertSession(db, { id: 's1', project: 'test--project', memoryId: 'mem-s1' });

--- a/utils.mjs
+++ b/utils.mjs
@@ -157,9 +157,11 @@ export function isRelatedToEpisode(episode, newFiles) {
  * @param {string} toolName Name of the tool (Edit, Write, Bash, etc.)
  * @param {object} input Tool input parameters
  * @param {string} resp Tool response text
+ * @param {object} [opts] Optional signals from detectBashSignificance
+ * @param {boolean} [opts.isError] If provided, overrides inline error regex detection
  * @returns {string} Concise description of the action
  */
-export function makeEntryDesc(toolName, input, resp) {
+export function makeEntryDesc(toolName, input, resp, opts) {
   switch (toolName) {
     case 'Edit':
       return `${basename(input.file_path || '')}: "${truncate(input.old_string || '', 40)}" → "${truncate(input.new_string || '', 40)}"`;
@@ -169,7 +171,9 @@ export function makeEntryDesc(toolName, input, resp) {
       return `Notebook cell: ${truncate(input.new_source || '', 60)}`;
     case 'Bash': {
       const cmd = truncate(input.command || '', 50);
-      const isErr = /error|fail|exception|panic/i.test(resp) && resp.length > 30;
+      // Use caller-provided bashSig.isError (word-boundary aware) when available;
+      // fall back to inline regex only for standalone callers (tests, etc.)
+      const isErr = opts?.isError ?? (/\berror\b|\bfail(ed|ure)?\b|\bexception\b|\bpanic\b/i.test(resp) && resp.length > 30);
       const snippet = truncate(resp, 60);
       return isErr ? `${cmd} → ERROR: ${snippet}` : `${cmd} → ${snippet}`;
     }


### PR DESCRIPTION
## Summary
- Fix false-positive ERROR labeling in `makeEntryDesc` — weak regex `/error|fail/i` replaced with word-boundary version `\berror\b|\bfail(ed|ure)?\b|\bexception\b|\bpanic\b` via caller-provided `bashSig.isError` override
- Improve 6 MCP tool descriptions and 4 skill descriptions from feature-driven to scenario-driven ("Use when:") for intelligent Claude Code auto-invocation
- Add `buildDegradedTitle` tab/CI-status cleanup, tier post-filter repositioning after PRF expansion, FTS fallback text extraction, registry list pagination, and test setup hardening

## Test plan
- [x] 1103 tests pass (36 test files)
- [x] ESLint clean
- [x] Pre-commit hook passes (version sync + lint + tests)
- [x] Manual verification: "Hispanic" no longer matches `\bpanic\b`, real `panic` still detected
- [x] Manual verification: vitest output with "errorRecall" test names no longer falsely labeled ERROR
- [x] Manual verification: all hooks fire < 100ms, no interference with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic deduplication of similar memory entries during maintenance
  * Enhanced search with fallback text extraction for better result discovery
  * Registry listing now supports `--limit` parameter with improved sorting

* **Bug Fixes**
  * Fixed memory search to consistently apply tier constraints across all result types
  * Improved error detection in observation descriptions

* **Documentation**
  * Expanded command descriptions with detailed usage guidance
  * Updated help text for better command discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->