### PR TITLE
fix(update): read running plugin version from CLAUDE_PLUGIN_ROOT in plugin mode

### DIFF
--- a/hook-update.mjs
+++ b/hook-update.mjs
@@ -277,6 +277,17 @@ export function compareVersions(a, b) {
 }
 
 export function getCurrentVersion() {
+  // In plugin mode INSTALL_DIR (~/.claude-mem-lite/) holds only the DB + runtime
+  // state — no package.json — so read the running plugin-cache version from
+  // CLAUDE_PLUGIN_ROOT first, else the update check sees '0.0.0' and nags every
+  // SessionStart. Fall back to the INSTALL_DIR read for non-plugin installs.
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (pluginRoot) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(pluginRoot, 'package.json'), 'utf8'));
+      return pkg.version;
+    } catch { /* fall through to INSTALL_DIR */ }
+  }
   try {
     const pkg = JSON.parse(readFileSync(join(INSTALL_DIR, 'package.json'), 'utf8'));
     return pkg.version;

--- a/tests/hook-update.test.mjs
+++ b/tests/hook-update.test.mjs
@@ -402,6 +402,20 @@ describe('code/data dir separation under relocation (D#27)', () => {
     expect(getCurrentVersion()).toBe('2.0.0');
   });
 
+  // Pure-plugin install: ~/.claude-mem-lite holds only DB + runtime state, no
+  // package.json, so INSTALL_DIR read fails and pre-fix returned '0.0.0' — which
+  // made checkForUpdate compute hasUpdate=true and nag every SessionStart. Fix
+  // reads the running plugin-cache version from CLAUDE_PLUGIN_ROOT.
+  it('getCurrentVersion reads CLAUDE_PLUGIN_ROOT package.json in plugin mode when the code dir has none', async () => {
+    const home = makeDir('mem-update-home');
+    mkdirSync(join(home, '.claude-mem-lite', 'runtime'), { recursive: true });  // state only, no package.json
+    const pluginRoot = makeDir('mem-plugin-root');
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ version: '3.84.0' }, null, 2));
+    const { getCurrentVersion } = await loadModule({ HOME: home, CLAUDE_PLUGIN_ROOT: pluginRoot });
+    // Pre-fix: no package.json in the code dir → catch → '0.0.0'.
+    expect(getCurrentVersion()).toBe('3.84.0');
+  });
+
   it('installExtractedRelease defaults its target to the homedir code dir, not CLAUDE_MEM_DIR', async () => {
     const { home, codeDir } = makeCodeHome('1.0.0');
     writeFileSync(join(codeDir, 'hook.mjs'), '// old hook');


### PR DESCRIPTION
Symptom: in plugin mode the SessionStart update banner nags on every session — e.g. `📦 claude-mem-lite: v3.84.0 available (current: v0.0.0)` — even when the plugin cache is already fully current.

Root cause: `getCurrentVersion()` in `hook-update.mjs` reads `join(INSTALL_DIR, "package.json")`, where `INSTALL_DIR = CODE_DIR = ~/.claude-mem-lite` (the data dir). A pure-plugin install keeps only the SQLite DB and runtime state there — there is no `package.json`. The read throws, the catch-all returns `"0.0.0"`, so `checkForUpdate()` always computes `hasUpdate=true`, persists `installedVersion: "0.0.0", updateAvailable: true` in `runtime/update-state.json`, and `getCachedUpdateBanner()` shows the banner every SessionStart.

Fix: in `getCurrentVersion()`, when `process.env.CLAUDE_PLUGIN_ROOT` is set, read `CLAUDE_PLUGIN_ROOT/package.json` first — that is the version of the code actually executing. Fall back to the existing `INSTALL_DIR` read for non-plugin installs, keeping the `"0.0.0"` last resort.

Test coverage: added a case to `tests/hook-update.test.mjs` alongside the existing `getCurrentVersion` tests — a plugin-mode home whose `~/.claude-mem-lite` has only `runtime/` (no `package.json`) plus a `CLAUDE_PLUGIN_ROOT` holding a versioned `package.json`; asserts `getCurrentVersion()` returns the plugin-root version. Verified it fails against the pre-fix code (returns `0.0.0`) and passes with the fix.

Test suite: `tests/hook-update.test.mjs` — 65 passed. Full `npm test` — 5318 passed, 1 pre-existing unrelated failure in `tests/cli-path-invocation.test.mjs` (`buildServerInstructions` length assertion) that also fails on clean `main` without this change. `eslint` clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version detection when the application runs in plugin mode.
  - Correctly reads the installed plugin version even when the standard installation location lacks version information.

- **Tests**
  - Added coverage for relocated plugin installations to ensure the correct version is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->